### PR TITLE
Add database and sample ingredient query

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -5,4 +5,4 @@ node_modules/
 yarn-error.log
 
 # Babel
-dist/
+.dist/

--- a/server/package.json
+++ b/server/package.json
@@ -19,24 +19,30 @@
   },
   "scripts": {
     "start": "yarn dev",
-    "server": "node ./dist/bin/www",
+    "server": "node ./.dist/bin/www",
     "build": "npm-run-all clean transpile",
     "dev": "NODE_ENV=development npm-run-all build server",
     "prod": "NODE_ENV=production npm-run-all build server",
-    "transpile": "babel src --out-dir dist",
-    "clean": "rimraf dist",
+    "transpile": "babel src --out-dir .dist",
+    "clean": "rimraf .dist",
     "watch:dev": "nodemon"
   },
   "dependencies": {
-    "@babel/cli": "^7.8.4",
-    "@babel/core": "^7.8.4",
-    "@babel/preset-env": "^7.8.4",
+    "@babel/polyfill": "^7.8.3",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
     "debug": "~2.6.9",
     "express": "~4.16.1",
     "morgan": "~1.9.1",
+    "n3": "^1.3.5",
     "nodemon": "^2.0.2",
+    "ramda": "^0.27.0",
+    "sparql-engine": "^0.7.1"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.8.4",
+    "@babel/core": "^7.8.4",
+    "@babel/preset-env": "^7.8.4",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2"
   },

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -3,6 +3,7 @@ import path from 'path';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import logger from 'morgan';
+import RecipeStore from './data/RecipeStore';
 
 const app = express();
 
@@ -17,17 +18,27 @@ app.use(cors());
 
 // Setup routes
 app.get('/', (req, res, next) => {
-    res.render('index', { title: 'Express' });
+  res.render('index', { title: 'Express' });
+});
+
+app.get('/ingredients', async (req, res) => {
+  try {
+    const allIngredients = await RecipeStore.allIngredients();
+    res.send(allIngredients);
+  } catch (err) {
+    console.err(err);
+    res.status(304).send({ error: err });
+  }
 });
 
 app.get('/recipes', (req, res) => {
-    const mockRecipeReturn = [
-      'Soup with eggs',
-      'Lasagna',
-      'Broccoli and Cheese',
-    ];
+  const mockRecipeReturn = [
+    'Soup with eggs',
+    'Lasagna',
+    'Broccoli and Cheese',
+  ];
 
-    res.send(mockRecipeReturn);
+  res.send(mockRecipeReturn);
 });
 
 export default app;

--- a/server/src/data/N3Graph.js
+++ b/server/src/data/N3Graph.js
@@ -1,0 +1,79 @@
+import { Store, DataFactory } from 'n3';
+import { Graph } from 'sparql-engine';
+
+const { namedNode, literal, defaultGraph, quad,
+  internal: { toId, fromId, Term },
+} = DataFactory;
+
+const toNode = term => {
+  if (term === null || term instanceof Term) {
+    return term;
+  }
+
+  // we assume term is a string
+  if (term.startsWith('?')) {
+    return null;
+  } else if (term.startsWith('http')) {
+    return namedNode(term);
+  } else {
+    return literal(term);
+  }
+};
+
+const toAlgebraTriple = (q) => {
+  return quad(
+    toId(q.subject),
+    toId(q.predicate),
+    toId(q.object)
+  );
+};
+
+// Format a triple pattern according to N3 API:
+// SPARQL variables must be replaced by `null` values
+const formatTriplePattern = (triple) => {
+  const subject = toNode(triple.subject);
+  const predicate = toNode(triple.predicate);
+  const object = toNode(triple.object);
+  return { subject, predicate, object }
+}
+
+export default class N3Graph extends Graph {
+  constructor () {
+    super();
+    this._store = new Store();
+  }
+
+  insert (triple) {
+    return new Promise((resolve, reject) => {
+      try {
+        this._store.addQuad(triple.subject, triple.predicate, triple.object);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    })
+  }
+
+  delete (triple) {
+    return new Promise((resolve, reject) => {
+      try {
+        this._store.removeQuad(triple.subject, triple.predicate, triple.object);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    })
+  }
+
+  find (triple) {
+    // console.log(triple);
+    const { subject, predicate, object } = formatTriplePattern(triple);
+    console.log({ subject, predicate, object });
+    return this._store.getQuads(subject, predicate, object).map(toAlgebraTriple);
+  }
+
+  estimateCardinality (triple) {
+    const { subject, predicate, object } = formatTriplePattern(triple);
+    return Promise.resolve(this._store.countQuads(subject, predicate, object));
+  }
+}

--- a/server/src/data/N3Graph.js
+++ b/server/src/data/N3Graph.js
@@ -43,7 +43,7 @@ export default class N3Graph extends Graph {
     this._store = new Store();
   }
 
-  insert (triple) {
+  insert(triple) {
     return new Promise((resolve, reject) => {
       try {
         this._store.addQuad(triple.subject, triple.predicate, triple.object);
@@ -54,7 +54,7 @@ export default class N3Graph extends Graph {
     })
   }
 
-  delete (triple) {
+  delete(triple) {
     return new Promise((resolve, reject) => {
       try {
         this._store.removeQuad(triple.subject, triple.predicate, triple.object);
@@ -65,15 +65,14 @@ export default class N3Graph extends Graph {
     })
   }
 
-  find (triple) {
+  find(triple) {
     // console.log(triple);
     const { subject, predicate, object } = formatTriplePattern(triple);
-    console.log({ subject, predicate, object });
     return this._store.getQuads(subject, predicate, object).map(toAlgebraTriple);
   }
 
-  estimateCardinality (triple) {
+  estimateCardinality(triple) {
     const { subject, predicate, object } = formatTriplePattern(triple);
     return Promise.resolve(this._store.countQuads(subject, predicate, object));
   }
-}
+};

--- a/server/src/data/RecipeStore.js
+++ b/server/src/data/RecipeStore.js
@@ -1,0 +1,115 @@
+import "regenerator-runtime/runtime";
+import * as R from 'ramda';
+import { Parser } from 'n3';
+import { HashMapDataset, PlanBuilder } from 'sparql-engine';
+import { generatePrefixes, stripPrefix, recipe, ingredient, rcp, pType } from './utils';
+import N3Graph from './N3Graph';
+
+const graph = new N3Graph();
+const dataset = new HashMapDataset('http://recipedia.com/', graph);
+
+console.log('Loading recipes...');
+
+// Load recipes into the graph
+const parser = new Parser();
+parser.parse(`
+  @prefix rcp: <http://recipedia.com/#> .
+  @prefix rci: <http://recipedia.com/ingredient#> .
+  @prefix alr: <https://www.allrecipes.com/recipe/> .
+  @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+  rci:butter a rcp:Ingredient .
+  rci:leek a rcp:Ingredient .
+  rci:chicken_broth a rcp:Ingredient .
+  rci:cornstarch a rcp:Ingredient .
+  rci:potato a rcp:Ingredient .
+  rci:cream a rcp:Ingredient .
+  rci:garlic a rcp:Ingredient .
+  rci:chicken_bouillon a rcp:Ingredient .
+  rci:sour_cream a rcp:Ingredient .
+  rci:cream_cheese a rcp:Ingredient .
+
+  alr:25708 a rcp:Recipe;
+            rcp:name "Potato Leek Soup III" ;
+            rcp:rating 4.5 ;
+            rcp:contains rci:butter ;
+            rcp:contains rci:leek ;
+            rcp:contains rci:chicken_broth ;
+            rcp:contains rci:cornstarch ;
+            rcp:contains rci:potato ;
+            rcp:contains rci:cream .
+
+  alr:25895 a rcp:Recipe ;
+            rcp:name "Slow Cooker Mashed Potatoes" ;
+            rcp:rating 4.5 ;
+            rcp:key rci:potato ;
+            rcp:contains rci:potato ;
+            rcp:contains rci:garlic ;
+            rcp:contains rci:chicken_bouillon ;
+            rcp:contains rci:sour_cream ;
+            rcp:contains rci:cream_cheese ;
+            rcp:contains rci:butter .
+`).forEach(quad => {
+  // console.log(quad);
+  graph._store.addQuad(quad);
+});
+
+Promise.all([
+  graph.estimateCardinality({
+    subject: null,
+    predicate: pType,
+    object: rcp('Ingredient')
+  }),
+  graph.estimateCardinality({
+    subject: null,
+    predicate: pType,
+    object: rcp('Recipe')
+  })
+]).then(([numIngredients, numRecipes]) => {
+  console.log(`${numIngredients} ingredients loaded.\n${numRecipes} recipes loaded.`);
+});
+
+// Creates a plan builder for the RDF dataset
+const builder = new PlanBuilder(dataset);
+
+const collect = it => {
+  return new Promise((resolve, reject) => {
+    const result = [];
+    it.subscribe(
+      bindings => result.push(bindings.toObject()),
+      err => reject(err),
+      () => resolve(result)
+    );
+  });
+};
+
+const runQuery = async (query) => {
+  const iterator = builder.build(query);
+  return await collect(iterator);
+};
+
+const getIngredient = R.pipe(
+  i => i['?i'],
+  stripPrefix('rci'),
+  i => i.replace('_', ' ')
+);
+
+const getAllIngredients = async () => {
+  const result = await runQuery(`
+    ${generatePrefixes([
+      'rcp',
+      'rci'
+    ])}
+    SELECT ?i WHERE {
+      ?i a rcp:Ingredient .
+    }
+  `);
+  return result.map(getIngredient).sort();
+};
+
+const RecipeStore = {
+  query: runQuery,
+  allIngredients: getAllIngredients,
+};
+
+export default RecipeStore;

--- a/server/src/data/mockRecipes.ttl
+++ b/server/src/data/mockRecipes.ttl
@@ -1,0 +1,36 @@
+@prefix rcp: <http://recipedia.com/#> .
+@prefix rci: <http://recipedia.com/ingredient#> .
+@prefix alr: <https://www.allrecipes.com/recipe/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+rci:butter a rcp:Ingredient .
+rci:leek a rcp:Ingredient .
+rci:chicken_broth a rcp:Ingredient .
+rci:cornstarch a rcp:Ingredient .
+rci:potato a rcp:Ingredient .
+rci:cream a rcp:Ingredient .
+rci:garlic a rcp:Ingredient .
+rci:chicken_bouillon a rcp:Ingredient .
+rci:sour_cream a rcp:Ingredient .
+rci:cream_cheese a rcp:Ingredient .
+
+alr:25708 a rcp:Recipe;
+          rcp:name "Potato Leek Soup III" ;
+          rcp:rating 4.5 ;
+          rcp:contains rci:butter ;
+          rcp:contains rci:leek ;
+          rcp:contains rci:chicken_broth ;
+          rcp:contains rci:cornstarch ;
+          rcp:contains rci:potato ;
+          rcp:contains rci:cream .
+
+alr:25895 a rcp:Recipe ;
+          rcp:name "Slow Cooker Mashed Potatoes" ;
+          rcp:rating 4.5 ;
+          rcp:key rci:potato ;
+          rcp:contains rci:potato ;
+          rcp:contains rci:garlic ;
+          rcp:contains rci:chicken_bouillon ;
+          rcp:contains rci:sour_cream ;
+          rcp:contains rci:cream_cheese ;
+          rcp:contains rci:butter .

--- a/server/src/data/utils.js
+++ b/server/src/data/utils.js
@@ -1,0 +1,34 @@
+import { DataFactory } from 'n3';
+
+const { namedNode } = DataFactory;
+
+const prefixes = {
+  rcp: "http://recipedia.com/#",
+  rci: "http://recipedia.com/ingredient#",
+  alr: "https://www.allrecipes.com/recipe/"
+};
+
+export const generatePrefixes = prefixList => {
+  return prefixList
+    .map(p => `PREFIX ${p}: <${prefixes[p]}>`)
+    .join('\n');
+};
+
+export const stripPrefix = prefix => {
+  const slicePos = prefixes[prefix].length;
+  return data => data.slice(slicePos);
+};
+
+export const recipe = (r) => {
+  return namedNode(prefixes.alr + r);
+};
+
+export const ingredient = (i) => {
+  return namedNode(prefixes.rci + i);
+}
+
+export const rcp = (r) => {
+  return namedNode(prefixes.rcp + r);
+}
+
+export const pType = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -628,6 +628,14 @@
     "@babel/helper-create-regexp-features-plugin" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
 
+"@babel/polyfill@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.8.3.tgz#2333fc2144a542a7c07da39502ceeeb3abe4debd"
+  integrity sha512-0QEgn2zkCzqGIkSWWAEmvxD7e00Nm9asTtQvi7HdlYvMhjy/J38V/1Y9ode0zEJeIuxAI0uftiAzqc7nVeWUGg==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/preset-env@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.8.4.tgz#9dac6df5f423015d3d49b6e9e5fa3413e4a72c4e"
@@ -723,6 +731,25 @@
     esutils "^2.0.2"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
+
+"@rdfjs/data-model@^1.1.1", "@rdfjs/data-model@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@rdfjs/data-model/-/data-model-1.1.2.tgz#e2f48a422c7e837b8a7d96d240732be3287df713"
+  integrity sha512-pk/G/JLYGaXesoBLvEmoC/ic0H3B79fTyS0Ujjh5YQB2DZW+mn05ZowFFv88rjB9jf7c1XE5XSmf8jzn6U0HHA==
+  dependencies:
+    "@types/rdf-js" "^2.0.1"
+
+"@types/node@*":
+  version "13.7.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.4.tgz#76c3cb3a12909510f52e5dc04a6298cdf9504ffd"
+  integrity sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==
+
+"@types/rdf-js@^2.0.1":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@types/rdf-js/-/rdf-js-2.0.11.tgz#b9e398504ceb9f00eaa3b3036b643dc3490cf362"
+  integrity sha512-GC5MZU2HbL5JnlrLAzoxSqLprqtKwocz0TNVugqM04t1ZeeNFpZRqqBQc9Jhev35hEwdH84siRLaCesxHHYlmA==
+  dependencies:
+    "@types/node" "*"
 
 abbrev@1:
   version "1.1.1"
@@ -853,6 +880,13 @@ binary-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
+
+binary-search-tree@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/binary-search-tree/-/binary-search-tree-0.2.6.tgz#c6d29194e286827fcffe079010e6bf77def10ce3"
+  integrity sha1-xtKRlOKGgn/P/geQEOa/d97xDOM=
+  dependencies:
+    underscore "~1.4.4"
 
 bindings@^1.5.0:
   version "1.5.0"
@@ -1122,6 +1156,11 @@ core-js-compat@^3.6.2:
   dependencies:
     browserslist "^4.8.3"
     semver "7.0.0"
+
+core-js@^2.6.5:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
+  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -1993,7 +2032,7 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
-lodash@^4.17.13:
+lodash@^4.17.13, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -2017,6 +2056,13 @@ lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -2121,6 +2167,11 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+moment@^2.22.2:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 morgan@~1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
@@ -2141,6 +2192,16 @@ ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+n3@^0.11.3:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/n3/-/n3-0.11.3.tgz#8e587495240dd21408c2c3aae385ec1651a837f8"
+  integrity sha512-Hk5GSXBeAZrYoqi+NeS/U0H47Hx0Lzj7K6nLWCZpC9E04iUwEwBcrlMb/5foAli7QF4newPNQQQGgM6IAxTxGg==
+
+n3@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/n3/-/n3-1.3.5.tgz#ea00062b64fef71dc3a92befc00413a733ef1029"
+  integrity sha512-McWb1tCWGGAmHeGEakqZj/UqxQR9cpEYZ/JivBj59YfiOAuaIWZxu0B+jnhbCwCZ2AsxdgQ5Dq8fehIJpYQaMQ==
 
 nan@^2.12.1:
   version "2.14.0"
@@ -2448,6 +2509,11 @@ qs@6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+ramda@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.0.tgz#915dc29865c0800bf3f69b8fd6c279898b59de43"
+  integrity sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==
+
 range-parser@~1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -2472,6 +2538,13 @@ rc@^1.0.1, rc@^1.1.6:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+rdf-string@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/rdf-string/-/rdf-string-1.3.1.tgz#a9f49db4dbe0ff06bb17bf46e0389862f6a77e49"
+  integrity sha512-Pcw6aZRfto2cZodK5kSqFZW8mz6nfKLxSfjOSrTi5ajb2CSIwzqGx7UniysgKoV2i7tQL5dpPgCgY80upCiRUw==
+  dependencies:
+    "@rdfjs/data-model" "^1.1.1"
 
 read-pkg@^3.0.0:
   version "3.0.0"
@@ -2522,6 +2595,11 @@ regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"
@@ -2615,6 +2693,13 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rxjs@^6.3.3:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
+  integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -2781,6 +2866,28 @@ source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+
+sparql-engine@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/sparql-engine/-/sparql-engine-0.7.1.tgz#aca410c6635e59507da9ba2e4ff8637d907b1543"
+  integrity sha512-2ycniVJ2SUKVatdDQN4x3qs/Mr9nmGQ/uv3FvyohVdy1BgIE6BNSMZkUCjo5DakiMxIWywPghdum50bs8zUI4w==
+  dependencies:
+    "@rdfjs/data-model" "^1.1.2"
+    binary-search-tree "^0.2.6"
+    lodash "^4.17.15"
+    lru-cache "^5.1.1"
+    moment "^2.22.2"
+    n3 "^0.11.3"
+    rdf-string "^1.3.1"
+    rxjs "^6.3.3"
+    sparqljs "^2.0.3"
+    uuid "^3.3.2"
+    xml "^1.0.1"
+
+sparqljs@^2.0.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-2.2.3.tgz#6eb7f5f69b27b99d3b646e89271c048bd61d9293"
+  integrity sha512-lrzSQadbkiQk4O6RjXJjec/EevVIsnAfbNK3t8XJtocogNojfQM7KC/UttyRTAq4IOXa0vRVoFTRapcbgFVRWg==
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -2957,6 +3064,11 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
+tslib@^1.9.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.0.tgz#f1f3528301621a53220d58373ae510ff747a66bc"
+  integrity sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==
+
 type-is@~1.6.16:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -2971,6 +3083,11 @@ undefsafe@^2.0.2:
   integrity sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=
   dependencies:
     debug "^2.2.0"
+
+underscore@~1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
+  integrity sha1-YaajIBBiKvoHljvzJSA88SI51gQ=
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -3078,6 +3195,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
+uuid@^3.3.2:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -3124,7 +3246,17 @@ xdg-basedir@^3.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
   integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
 
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
This PR adds the [sparql-engine](https://www.npmjs.com/package/sparql-engine) and [n3](https://www.npmjs.com/package/n3) packages to provide querying services on the server-side.

We are using an in-memory database provided by `n3` (raw data operations) wrapped in `sparql-engine` for query parsing, optimisation and execution. The database is loaded during initialisation.

As a sample use-case, I added the `/ingredients` endpoint, which returns the names of all valid ingredients from the database.