### PR TITLE
Persist data to non temp folder

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   zero:
     image: dgraph/dgraph:latest
     volumes:
-      - /tmp/data:/dgraph
+      - /var/recipedia/data:/dgraph
     ports:
       - 5080:5080
       - 6080:6080
@@ -17,7 +17,7 @@ services:
   alpha:
     image: dgraph/dgraph:latest
     volumes:
-      - /tmp/data:/dgraph
+      - /var/recipedia/data:/dgraph
       - ./db/launch-alpha.sh:/dgraph/launch-alpha.sh
       - type: bind
         source: ./db/data


### PR DESCRIPTION
Ok so I figured out why sometimes I wasn't getting data on the server. It turns out that the file system in the container persists between booting up, and since we were using the `/tmp` folder the server would stop working on reboot

I moved the database to the `/var/recipedia/data` folder instead which should fix that issue