### PR TITLE
Allow the search bar to 'stick' to the top of the page

### DIFF
--- a/client/src/RecipediaApp.js
+++ b/client/src/RecipediaApp.js
@@ -35,12 +35,18 @@ const noResultsStyle = {
 
 const withResultsStyle = {
   upperContainer: {
+    position: "-webkit-sticky",
+    position: "sticky",
+    top: 0,
+    backdropFilter: "blur(5px)",
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    width: "81%",
-    marginLeft: "7%",
-    maxWidth: "90%"
+    width: "83%",
+    // marginLeft: "7%",
+    padding: "0 9%",
+    maxWidth: "90%",
+    zIndex: "10",
   },
   title: {
     marginTop: 100,

--- a/client/src/components/SearchBar.js
+++ b/client/src/components/SearchBar.js
@@ -16,6 +16,7 @@ const CORNER_RADIUS = 15;
 const style = {
   outerSearchBox: {
     border: `${BORDER_WIDTH}px solid ${colours.LIGHT_BACKGROUND_DEFAULT_COLOUR}`,
+    backgroundColor: "white",
     borderRadius: `${CORNER_RADIUS}px`,
     padding: CORNER_RADIUS - BORDER_WIDTH,
     boxShadow: "0px 8px 15px rgba(0, 0, 0, 0.1)",

--- a/client/src/components/UserGuide.js
+++ b/client/src/components/UserGuide.js
@@ -20,7 +20,12 @@ const localStyle = {
   },
   hide: {
     opacity: "0"
-  }
+  },
+  stick: {
+    position: "-webkit-sticky",
+    position: "sticky",
+    top: "0",
+  },
 };
 
 type Props = {};

--- a/client/src/styles/userguide.module.css
+++ b/client/src/styles/userguide.module.css
@@ -54,7 +54,7 @@
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.2);
   position: absolute;
   left: 2%;
-  top: 2%;
+  margin-top: 2%;
   padding: 0 15px;
   box-sizing: border-box;
   transform-origin: top left;
@@ -66,7 +66,7 @@
 .guideScrollContainer {
   width: 100%;
   height: 100%;
-  padding: 0 10px;
+  padding: 10px;
   overflow: auto;
   box-sizing: border-box;
   transition: opacity 0.5s;


### PR DESCRIPTION
Search bar now sticks to the top of the page when scrolling through recipes (#97 )

Bonus: The "Top" part of the searchbar will blur so to keep focus on the recipe cards below.

NOTE: This feature doesn't work on Internet Explorer