### PR TITLE
Recipe card click behavior

### DIFF
--- a/client/src/components/RecipeCard.js
+++ b/client/src/components/RecipeCard.js
@@ -285,6 +285,27 @@ class PrimaryRecipeCard extends React.PureComponent<Props, PrimaryCardState> {
   }
 }
 
+const LEFT_BUTTON = 0;
+const MIDDLE_BUTTON = 1;
+const RIGHT_BUTTON = 2;
+
+const recipeMouseDownHandler = (recipe_url: string) => event => {
+  switch (event.button) {
+    case LEFT_BUTTON:
+      // Open in the same tab
+      window.open(recipe_url, "_self");
+      break;
+    case MIDDLE_BUTTON:
+      // Open in a different tab
+      window.open(recipe_url, "_blank");
+      break;
+    case RIGHT_BUTTON:
+      break; // do nothing
+    default:
+      break;
+  }
+};
+
 class RecipeCard extends React.PureComponent<Props> {
   render() {
     const { recipe } = this.props;
@@ -294,7 +315,7 @@ class RecipeCard extends React.PureComponent<Props> {
     return (
       <div
         className={styles.RecipeCards}
-        onClick={() => window.open(recipe_url, "_blank")}
+        onMouseDown={recipeMouseDownHandler(recipe_url)}
       >
         <RecipeLogo logoImg={allRecipesLogo} logoAlt="A|R" />
         <PrimaryRecipeCard recipe={recipe} />

--- a/client/src/components/TokenCreator.js
+++ b/client/src/components/TokenCreator.js
@@ -17,19 +17,6 @@ import styles from "styles/searchbar.module.css";
 
 import type { State } from "types/states";
 
-const style = {
-  noError: {
-    opacity: 0
-    // width: 0,
-    // padding: 0,
-  },
-  displayError: {
-    opacity: 1
-    // width: "200px",
-    // padding: "10px",
-  }
-};
-
 type Props = {
   autoFocus: boolean,
   placeholder: string,

--- a/client/src/models/SearchToken.js
+++ b/client/src/models/SearchToken.js
@@ -68,7 +68,7 @@ export default class SearchToken {
       return null;
     }
 
-    const value = valueStr != "" ? valueStr : null;
+    const value = valueStr !== "" ? valueStr : null;
     return new SearchToken(toKeyword(keywordStr), value);
   }
 }

--- a/client/src/reducers/searchbarReducer.js
+++ b/client/src/reducers/searchbarReducer.js
@@ -20,7 +20,7 @@ import type { Action } from "actions";
 import type { SearchbarState } from "types/states";
 import type { Diet } from "models/diets";
 import type { Ingredient } from "models/ingredient";
-import type { Input, InputType } from "models/input";
+import type { Input } from "models/input";
 import type { Keyword } from "models/keywords";
 
 const MAX_AUTOCOMPLETE_ITEMS = 7;


### PR DESCRIPTION
Now, left clicking on a recipe opens that recipe in the same tab.
Centre clicking is now supported, and opens the recipe in a different tab (old behavior)

closes #140 
closes #141 